### PR TITLE
APPSREPO-338 : Bring the existing bencharmark-device-sync driver up-to-date

### DIFF
--- a/util/src/main/java/org/alfresco/bm/site/SiteDataServiceImpl.java
+++ b/util/src/main/java/org/alfresco/bm/site/SiteDataServiceImpl.java
@@ -83,7 +83,6 @@ public class SiteDataServiceImpl implements SiteDataService, InitializingBean
         DBObject idxSiteMember = BasicDBObjectBuilder.start()
                 .append(SiteMemberData.FIELD_SITE_ID, 1)
                 .append(SiteMemberData.FIELD_USERNAME, 1)
-                .append("unique", Boolean.TRUE)
                 .get();
         DBObject optSiteMember = BasicDBObjectBuilder.start()
                 .append("name", "idx_SiteMember")


### PR DESCRIPTION
   - index properties like 'unique' cannot be set on the index key. latest versions of MongoDB do not ignore this error